### PR TITLE
restore idempotence

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,14 +45,21 @@
   - set_fact:
       sshd_additional_root_cfg: "{{ sshd_additional_user_cfg | selectattr('name', 'eq', 'root') | list }}"
 
-  - set_fact:
-      root_authorized_keys: "{{ sshd_additional_root_cfg[0].authorized_keys + ssh_authorized_keys }}"
+  - name: Merge ssh_authorized_keys with additional keys for root
+    set_fact:
+      sshd_root_authorized_keys: "{{ sshd_additional_root_cfg[0].authorized_keys + ssh_authorized_keys }}"
+    when: sshd_additional_root_cfg != []
+
+  - name: Use ssh_authorized_keys as sshd_root_authorized_keys
+    set_fact:
+      sshd_root_authorized_keys: "{{ ssh_authorized_keys }}"
+    when: sshd_additional_root_cfg == []
 
   - name: Configure authorized keys of root
     include_tasks: userconfig.yml
     with_items:
       - name: root
-        authorized_keys: "{{ root_authorized_keys }}"
+        authorized_keys: "{{ sshd_root_authorized_keys }}"
         exclusive: "{{ ssh_manage_root_keys_exclusively }}"
         deploy_in_etc: "{{ ssh_deploy_root_keys_in_etc }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,11 +42,17 @@
       group: root
       mode: 0644
 
+  - set_fact:
+      sshd_additional_root_cfg: "{{ sshd_additional_user_cfg | selectattr('name', 'eq', 'root') | list }}"
+
+  - set_fact:
+      root_authorized_keys: "{{ sshd_additional_root_cfg[0].authorized_keys + ssh_authorized_keys }}"
+
   - name: Configure authorized keys of root
     include_tasks: userconfig.yml
     with_items:
       - name: root
-        authorized_keys: "{{ ssh_authorized_keys }}"
+        authorized_keys: "{{ root_authorized_keys }}"
         exclusive: "{{ ssh_manage_root_keys_exclusively }}"
         deploy_in_etc: "{{ ssh_deploy_root_keys_in_etc }}"
 
@@ -62,7 +68,7 @@
   - name: Configure additional users
     when: sshd_additional_user_cfg != []
     include_tasks: userconfig.yml
-    with_items: "{{ sshd_additional_user_cfg }}"
+    with_items: "{{ sshd_additional_user_cfg | selectattr('name', 'ne', 'root') | list }}"
 
   - name: Deploy .k5login for root
     become: True


### PR DESCRIPTION
In Ansible the root-keys are set by ssh_authorized_keys. However, if we want to add authorized keys to root for only specific servers, we use sshd_additional_user_cfg for the root user.
This feature was probably implemented for setting keys for different users and not additional keys for root, because currently it then first sets the ssh_authorized_keys and thus removes our additional key and then adds it again when it does the "configure additional users".
This works but makes the role display as changed every time it is rolled out.

This PR first merges the additional root keys in sshd_additional_user_cfg with ssh_authorized keys, and in the task "configure additional users" only configures the keys that are not root.